### PR TITLE
connection attribute of the Thread element is configured with the incorrect type.

### DIFF
--- a/Protocol/protocol.xsd
+++ b/Protocol/protocol.xsd
@@ -7660,7 +7660,7 @@ As a bus address is not always needed, the default value can also be set to "fal
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
-                                    <xs:attribute name="connection" type="dis:TypeSemicolonSeparatedNumbers" use="required">
+                                    <xs:attribute name="connection" type="dis:TypeCommaSeparatedNumbers" use="required">
                                         <xs:annotation>
                                             <xs:documentation>
                                                 <![CDATA[When you create an additional thread, you have to link it to a particular connection.<br />


### PR DESCRIPTION
Needs to be merged together with the [PR](https://github.com/SkylineCommunications/dataminer-docs/pull/3750) in the dataminer-docs repository.