### PR TITLE
Added 'Processes' units

### DIFF
--- a/Protocol/uom.xsd
+++ b/Protocol/uom.xsd
@@ -6650,6 +6650,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="Processes">
+                <xs:annotation>
+                    <xs:documentation>processes</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>processes</slu:name>
+                        <slu:ignoreInDescription>false</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="ps">
                 <xs:annotation>
                     <xs:documentation>picosecond</xs:documentation>


### PR DESCRIPTION
## Description
I was working on the Microsoft Platform Snmp connector.
https://collaboration.dataminer.services/task/247248
The code owner and I found a use case to include processes as a unit for a parameter but it's missing.
