### PR TITLE
Changed newly added units from 'Processes' to 'Process(es)'

### DIFF
--- a/Protocol/uom.xsd
+++ b/Protocol/uom.xsd
@@ -6695,11 +6695,11 @@ DATE        VERSION     AUTHOR          COMMENTS
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
-            <xs:enumeration value="Processes">
+            <xs:enumeration value="Process(es)">
                 <xs:annotation>
-                    <xs:documentation>processes</xs:documentation>
+                    <xs:documentation>process(es)</xs:documentation>
                     <xs:appinfo>
-                        <slu:name>processes</slu:name>
+                        <slu:name>process(es)</slu:name>
                         <slu:ignoreInDescription>false</slu:ignoreInDescription>
                     </xs:appinfo>
                 </xs:annotation>


### PR DESCRIPTION
Synced with code owner of microsoft platform.
There are cases where we have only 1 process.
Thus, it might be more accurate to refer to it as 1 Process(es) instead of 1 Processes for the above usecase.