### PR TITLE
Added new units (Transaction, Transactions/s, Connection/s)

### DIFF
--- a/Protocol/uom.xsd
+++ b/Protocol/uom.xsd
@@ -7652,6 +7652,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="Transactions">
+                <xs:annotation>
+                    <xs:documentation>transactions</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>transactions</slu:name>
+                        <slu:ignoreInDescription>false</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="Ts">
                 <xs:annotation>
                     <xs:documentation>terasecond</xs:documentation>

--- a/Protocol/uom.xsd
+++ b/Protocol/uom.xsd
@@ -950,6 +950,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="Connections/s">
+                <xs:annotation>
+                    <xs:documentation>connections per second</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>connections per second</slu:name>
+                        <slu:ignoreInDescription>false</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="cPa">
                 <xs:annotation>
                     <xs:documentation>centipascal</xs:documentation>
@@ -7657,6 +7666,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     <xs:documentation>transactions</xs:documentation>
                     <xs:appinfo>
                         <slu:name>transactions</slu:name>
+                        <slu:ignoreInDescription>false</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Transactions/s">
+                <xs:annotation>
+                    <xs:documentation>transactions per second</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>transactions per second</slu:name>
                         <slu:ignoreInDescription>false</slu:ignoreInDescription>
                     </xs:appinfo>
                 </xs:annotation>


### PR DESCRIPTION
I was working on the F5 BIG-IP LTM connector.
https://collaboration.dataminer.services/task/261239
The newly added parameters do not have the Transaction unit, Transaction/s unit, and connections/s unit, thus we need to add the missing unit.
