### PR TITLE
Add 'Retries' enumeration to uom.xsd

### DIFF
--- a/Protocol/uom.xsd
+++ b/Protocol/uom.xsd
@@ -7085,6 +7085,15 @@ DATE        VERSION     AUTHOR          COMMENTS
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="Retries">
+                <xs:annotation>
+                    <xs:documentation>retries</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>retries</slu:name>
+                        <slu:ignoreInDescription>true</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="Rows">
                 <xs:annotation>
                     <xs:documentation>rows</xs:documentation>


### PR DESCRIPTION
## Description

Retries is added in the list of possible units. In some cases, 'Retries' can be used as a unit to represent the number of times a communication, ... is retried.
