### PR TITLE
Add percent per second units

### DIFF
--- a/Protocol/uom.xsd
+++ b/Protocol/uom.xsd
@@ -22,6 +22,15 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="%/s">
+                <xs:annotation>
+                    <xs:documentation>percent per second</xs:documentation>
+                    <xs:appinfo>
+                        <slu:name>percent per second</slu:name>
+                        <slu:ignoreInDescription>false</slu:ignoreInDescription>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="%RH">
                 <xs:annotation>
                     <xs:documentation>relative humidity</xs:documentation>


### PR DESCRIPTION
## Description

The units added will represent the rate of change of a percentage value over time. For example, the ramp-up slope of a rectifier.

## Documentation

If this pull request affects functionality described in the documentation, please ensure the following:

1. Open a related pull request in **SkylineCommunications/dataminer-docs** to update the relevant documentation.
2. Link this PR in the comments of the related docs PR. https://github.com/SkylineCommunications/dataminer-docs/pull/6073
3. (optional) Link the docs PR in the comments of this PR for visibility (e.g., `SkylineCommunications/dataminer-docs#PR_ID`).

If no documentation changes are required, please confirm that the documentation is already up to date.
